### PR TITLE
Audit fixes

### DIFF
--- a/contracts/JointProvider.sol
+++ b/contracts/JointProvider.sol
@@ -41,7 +41,7 @@ contract JointProvider is BaseStrategy {
 
     function _initializeStrat(address _oracle) internal {
         oracle = IPriceFeed(_oracle);
-        healthCheck = address(0xDDCea799fF1699e98EDF118e0629A974Df7DF012); // health.ychad.eth
+        healthCheck = address(0xDDCea799fF1699e98EDF118e0629A974Df7DF012);
     }
 
     function setRebalancer(address payable _rebalancer) external onlyGovernance {
@@ -205,7 +205,7 @@ contract JointProvider is BaseStrategy {
         return oracle.decimals();
     }
 
-    function getGovernance() public view returns (address){
-        return vault.governance();
+    function isVaultManagers(address _address) public view returns (bool){
+        return _address == vault.governance() || _address == vault.management();
     }
 }

--- a/contracts/JointProvider.sol
+++ b/contracts/JointProvider.sol
@@ -125,7 +125,7 @@ contract JointProvider is BaseStrategy {
         // Report overpayment as profit
         if (_debtPayment > _debtOutstanding) {
             _profit += _debtPayment.sub(_debtOutstanding);
-            _debtPayment = _debtPayment.sub(_profit);
+            _debtPayment = _debtOutstanding;
         }
 
         beforeWant = balanceOfWant();

--- a/contracts/JointProvider.sol
+++ b/contracts/JointProvider.sol
@@ -108,6 +108,10 @@ contract JointProvider is BaseStrategy {
     }
 
     function prepareReturn(uint _debtOutstanding) internal override returns (uint _profit, uint _loss, uint _debtPayment) {
+        uint beforeWant = balanceOfWant();
+        rebalancer.collectTradingFees();
+        _profit += balanceOfWant().sub(beforeWant);
+
         if (_debtOutstanding > 0) {
             if (vault.strategies(address(this)).debtRatio == 0) {
                 _debtPayment = liquidateAllPositions();

--- a/contracts/JointProvider.sol
+++ b/contracts/JointProvider.sol
@@ -120,16 +120,13 @@ contract JointProvider is BaseStrategy {
         // Interestingly, if you overpay on debt payment, the overpaid amount just sits in the strat.
         // Report overpayment as profit
         if (_debtPayment > _debtOutstanding) {
-            _profit = _debtPayment.sub(_debtOutstanding);
+            _profit += _debtPayment.sub(_debtOutstanding);
             _debtPayment = _debtPayment.sub(_profit);
         }
 
-        uint beforeWant = balanceOfWant();
-        rebalancer.collectTradingFees();
+        beforeWant = balanceOfWant();
         rebalancer.sellRewards();
-        uint afterWant = balanceOfWant();
-
-        _profit += afterWant.sub(beforeWant);
+        _profit += balanceOfWant().sub(beforeWant);
 
         if (_profit > _loss) {
             _profit = _profit.sub(_loss);

--- a/contracts/Rebalancer.sol
+++ b/contracts/Rebalancer.sol
@@ -199,7 +199,7 @@ contract Rebalancer {
     function shouldTend() public view returns (bool _shouldTend){
         // 18 == decimals of USD
         uint debtAUsd = _adjustDecimals(providerA.totalDebt().mul(providerA.getPriceFeed()).div(10 ** providerA.getPriceFeedDecimals()), _decimals(tokenA), 18);
-        uint debtBUsd = _adjustDecimals(providerB.totalDebt().mul(providerB.getPriceFeed()).div(10 ** providerA.getPriceFeedDecimals()), _decimals(tokenB), 18);
+        uint debtBUsd = _adjustDecimals(providerB.totalDebt().mul(providerB.getPriceFeed()).div(10 ** providerB.getPriceFeedDecimals()), _decimals(tokenB), 18);
         uint debtTotalUsd = debtAUsd.add(debtBUsd);
         uint idealAUsd = debtAUsd.add(debtBUsd).mul(currentWeightA()).div(1e18);
         uint idealBUsd = debtAUsd.add(debtBUsd).sub(idealAUsd);

--- a/contracts/Rebalancer.sol
+++ b/contracts/Rebalancer.sol
@@ -212,6 +212,8 @@ contract Rebalancer {
         uint idealAUsd = debtTotalUsd.mul(currentWeightA()).div(1e18);
         uint idealBUsd = debtTotalUsd.sub(idealAUsd);
 
+        if (debtAUsd == 0 || debtBUsd == 0) return;
+
         uint weight = debtAUsd.mul(1e18).div(debtTotalUsd);
 
         // If it hits weight boundary, tend so that we can disable swaps. If already disabled, no need to tend again.

--- a/contracts/Rebalancer.sol
+++ b/contracts/Rebalancer.sol
@@ -276,7 +276,6 @@ contract Rebalancer {
         }
 
         lbp.updateWeightsGradually(now, now, newWeights);
-        bool atLimit = newWeights[0] == 0.9 * 1e18 || newWeights[0] == 0.1 * 1e18;
 
         uint looseA = looseBalanceA();
         uint looseB = looseBalanceB();
@@ -285,12 +284,13 @@ contract Rebalancer {
         maxAmountsIn[0] = looseA;
         maxAmountsIn[1] = looseB;
 
-        // re-enter pool with max funds at the appropriate weights
+        // Re-enter pool with max funds at the appropriate weights.
         uint[] memory amountsIn = new uint[](2);
         amountsIn[0] = looseA;
         amountsIn[1] = looseB;
 
         bytes memory userData;
+
         if (initJoin) {
             userData = abi.encode(IBalancerVault.JoinKind.INIT, amountsIn);
             initJoin = false;

--- a/contracts/Rebalancer.sol
+++ b/contracts/Rebalancer.sol
@@ -486,7 +486,7 @@ contract Rebalancer {
         return lbp.getNormalizedWeights()[1];
     }
 
-    function _decimals(IERC20 _token) internal view returns (uint _decimals){
+    function _decimals(IERC20 _token) internal view returns (uint){
         return ERC20(address(_token)).decimals();
     }
 

--- a/contracts/Rebalancer.sol
+++ b/contracts/Rebalancer.sol
@@ -502,6 +502,16 @@ contract Rebalancer {
         }
     }
 
+    function getPublicSwap() public view returns (bool){
+        return lbp.getSwapEnabled();
+    }
+
+    // false = public swap will automatically be enabled when conditions are good
+    // true = public swap will stay disabled until this is flipped to true
+    function setStayDisabled(bool _disable) public onlyVaultManagers {
+        stayDisabled = _disable;
+    }
+
     receive() external payable {}
 }
 

--- a/contracts/Rebalancer.sol
+++ b/contracts/Rebalancer.sol
@@ -43,7 +43,7 @@ contract Rebalancer {
         require(
             _to == address(providerA) ||
             _to == address(providerB) ||
-            _to == providerA.getGovernance(), "!allowed");
+            providerA.isVaultManagers(_to), "!allowed");
         _;
     }
 
@@ -51,17 +51,12 @@ contract Rebalancer {
         require(
             msg.sender == address(providerA) ||
             msg.sender == address(providerB) ||
-            msg.sender == providerA.getGovernance(), "!allowed");
+            providerA.isVaultManagers(msg.sender), "!allowed");
         _;
     }
 
-    modifier onlyGov{
-        require(msg.sender == providerA.getGovernance(), "!governance");
-        _;
-    }
-
-    modifier onlyAuthorized() {
-        require(msg.sender == providerA.strategist() || msg.sender == providerA.getGovernance(), "!authorized");
+    modifier onlyVaultManagers{
+        require(providerA.isVaultManagers(msg.sender), "!governance");
         _;
     }
 
@@ -380,7 +375,7 @@ contract Rebalancer {
         tokenB.approve(address(uniswap), max);
     }
 
-    function setReward(address _reward) public onlyGov {
+    function setReward(address _reward) public onlyVaultManagers {
         reward.approve(address(uniswap), 0);
         reward = IERC20(_reward);
         reward.approve(address(uniswap), max);
@@ -399,15 +394,15 @@ contract Rebalancer {
         return _path;
     }
 
-    function setSwapFee(uint _fee) external onlyAuthorized {
+    function setSwapFee(uint _fee) external onlyVaultManagers {
         lbp.setSwapFeePercentage(_fee);
     }
 
-    function setPublicSwap(bool _isPublic) external onlyGov {
+    function setPublicSwap(bool _isPublic) external onlyVaultManagers {
         lbp.setSwapEnabled(_isPublic);
     }
 
-    function setTendBuffer(uint _newBuffer) external onlyAuthorized {
+    function setTendBuffer(uint _newBuffer) external onlyVaultManagers {
         require(_newBuffer < lbp.getSwapFeePercentage());
         tendBuffer = _newBuffer;
     }

--- a/contracts/Rebalancer.sol
+++ b/contracts/Rebalancer.sol
@@ -245,8 +245,8 @@ contract Rebalancer {
         }
 
         // 18 == decimals of USD
-        uint debtAUsd = _adjustDecimals(providerA.totalDebt().mul(providerA.getPriceFeed()), _decimals(tokenA), 18);
-        uint debtBUsd = _adjustDecimals(providerB.totalDebt().mul(providerB.getPriceFeed()), _decimals(tokenB), 18);
+        uint debtAUsd = _adjustDecimals(providerA.totalDebt().mul(providerA.getPriceFeed()).div(10 ** providerA.getPriceFeedDecimals()), _decimals(tokenA), 18);
+        uint debtBUsd = _adjustDecimals(providerB.totalDebt().mul(providerB.getPriceFeed()).div(10 ** providerB.getPriceFeedDecimals()), _decimals(tokenB), 18);
         uint debtTotalUsd = debtAUsd.add(debtBUsd);
 
         // update weights to their appropriate priced balances

--- a/contracts/Rebalancer.sol
+++ b/contracts/Rebalancer.sol
@@ -39,6 +39,9 @@ contract Rebalancer {
     bool internal initJoin;
     uint public tendBuffer;
 
+    // publicSwap flips on and off depending on weight balance conditions.
+    // This acts as a master switch to stay disabled during emergencies.
+    bool public stayDisabled;
     modifier toOnlyAllowed(address _to){
         require(
             _to == address(providerA) ||

--- a/contracts/Rebalancer.sol
+++ b/contracts/Rebalancer.sol
@@ -520,7 +520,7 @@ contract Rebalancer {
         stayDisabled = _disable;
     }
 
-    function setWeightBounds(uint _upper, uint _lower){
+    function setWeightBounds(uint _upper, uint _lower) public onlyVaultManagers {
         require(_upper < .99 * 1e18);
         require(_lower > .01 * 1e18);
         require(_upper + lowerBound == 1 * 1e18);

--- a/contracts/Rebalancer.sol
+++ b/contracts/Rebalancer.sol
@@ -212,7 +212,7 @@ contract Rebalancer {
         uint idealAUsd = debtTotalUsd.mul(currentWeightA()).div(1e18);
         uint idealBUsd = debtTotalUsd.sub(idealAUsd);
 
-        if (debtAUsd == 0 || debtBUsd == 0) return;
+        if (debtAUsd == 0 || debtBUsd == 0) return false;
 
         uint weight = debtAUsd.mul(1e18).div(debtTotalUsd);
 

--- a/contracts/Rebalancer.sol
+++ b/contracts/Rebalancer.sol
@@ -201,8 +201,8 @@ contract Rebalancer {
         uint debtAUsd = _adjustDecimals(providerA.totalDebt().mul(providerA.getPriceFeed()).div(10 ** providerA.getPriceFeedDecimals()), _decimals(tokenA), 18);
         uint debtBUsd = _adjustDecimals(providerB.totalDebt().mul(providerB.getPriceFeed()).div(10 ** providerB.getPriceFeedDecimals()), _decimals(tokenB), 18);
         uint debtTotalUsd = debtAUsd.add(debtBUsd);
-        uint idealAUsd = debtAUsd.add(debtBUsd).mul(currentWeightA()).div(1e18);
-        uint idealBUsd = debtAUsd.add(debtBUsd).sub(idealAUsd);
+        uint idealAUsd = debtTotalUsd.mul(currentWeightA()).div(1e18);
+        uint idealBUsd = debtTotalUsd.sub(idealAUsd);
 
         uint weight = debtAUsd.mul(1e18).div(debtTotalUsd);
         if (weight > 0.95 * 1e18 || weight < 0.05 * 1e18) {

--- a/contracts/Rebalancer.sol
+++ b/contracts/Rebalancer.sol
@@ -211,21 +211,21 @@ contract Rebalancer {
             return true;
         }
 
-        uint amountIn = _adjustDecimals(idealAUsd.sub(debtAUsd).mul(10 ** providerA.getPriceFeedDecimals()).div(providerA.getPriceFeed()), 18, _decimals(tokenA));
-        uint amountOutIfNoSlippage = _adjustDecimals(debtBUsd.sub(idealBUsd).mul(10 ** providerB.getPriceFeedDecimals()).div(providerB.getPriceFeed()), 18, _decimals(tokenB));
+        uint amountIn;
+        uint amountOutIfNoSlippage;
         uint amountOut;
 
-
         if (idealAUsd > debtAUsd) {
+            amountIn = _adjustDecimals(idealAUsd.sub(debtAUsd).mul(10 ** providerA.getPriceFeedDecimals()).div(providerA.getPriceFeed()), 18, _decimals(tokenA));
+            amountOutIfNoSlippage = _adjustDecimals(debtBUsd.sub(idealBUsd).mul(10 ** providerB.getPriceFeedDecimals()).div(providerB.getPriceFeed()), 18, _decimals(tokenB));
             amountOut = BalancerMathLib.calcOutGivenIn(pooledBalanceA(), currentWeightA(), pooledBalanceB(), currentWeightB(), amountIn, 0);
         } else {
-            uint temp = amountIn;
-            amountIn = amountOutIfNoSlippage;
-            amountOutIfNoSlippage = temp;
+            amountIn = _adjustDecimals(debtBUsd.sub(idealBUsd).mul(10 ** providerB.getPriceFeedDecimals()).div(providerB.getPriceFeed()), 18, _decimals(tokenB));
+            amountOutIfNoSlippage = _adjustDecimals(idealAUsd.sub(debtAUsd).mul(10 ** providerA.getPriceFeedDecimals()).div(providerA.getPriceFeed()), 18, _decimals(tokenA));
             amountOut = BalancerMathLib.calcOutGivenIn(pooledBalanceB(), currentWeightB(), pooledBalanceA(), currentWeightA(), amountIn, 0);
         }
 
-        // maximum positive slippage for user trading. Evaluate that against our fees.
+        // maximum positive slippage for arber. Evaluate that against our fees.
         if (amountOut > amountOutIfNoSlippage) {
             uint slippage = amountOut.sub(amountOutIfNoSlippage).mul(10 ** (idealAUsd > debtAUsd ? _decimals(tokenB) : _decimals(tokenA))).div(amountOutIfNoSlippage);
             return slippage > lbp.getSwapFeePercentage().sub(tendBuffer);

--- a/interfaces/BalancerV2.sol
+++ b/interfaces/BalancerV2.sol
@@ -48,6 +48,7 @@ interface ILiquidityBootstrappingPool {
 
     function setSwapEnabled(bool) external;
 
+    function getSwapEnabled() external view returns (bool);
     function getVault() external view returns (address);
 
     function onSwap(

--- a/interfaces/BalancerV2.sol
+++ b/interfaces/BalancerV2.sol
@@ -49,6 +49,7 @@ interface ILiquidityBootstrappingPool {
     function setSwapEnabled(bool) external;
 
     function getSwapEnabled() external view returns (bool);
+
     function getVault() external view returns (address);
 
     function onSwap(

--- a/interfaces/IJointProvider.sol
+++ b/interfaces/IJointProvider.sol
@@ -18,7 +18,7 @@ interface IJointProvider {
 
     function getPriceFeedDecimals() external view returns (uint256 _dec);
 
-    function getGovernance() external view returns (address);
+    function isVaultManagers(address) external view returns (bool);
 
     function strategist() external view returns (address);
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def transferToRando(accounts, tokenA, tokenB, rando, whaleA, whaleB):
 
     tokenA.transfer(rando, amount, {"from": whaleA})
 
-    amount = 1000 * 10 ** tokenB.decimals()
+    amount = 1_000 * 10 ** tokenB.decimals()
     # In order to get some funds for the token you are about to use,
     # it impersonate an exchange address to use it's funds.
 
@@ -136,6 +136,7 @@ def vaultA(pm, gov, rewards, guardian, management, tokenA):
     vault.initialize(tokenA, gov, rewards, "", "", guardian, management, {"from": gov})
     vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
     vault.setManagement(management, {"from": gov})
+    vault.setManagementFee(0, {"from": gov})
     yield vault
 
 
@@ -146,6 +147,7 @@ def vaultB(pm, gov, rewards, guardian, management, tokenB):
     vault.initialize(tokenB, gov, rewards, "", "", guardian, management, {"from": gov})
     vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
     vault.setManagement(management, {"from": gov})
+    vault.setManagementFee(0, {"from": gov})
     yield vault
 
 
@@ -248,7 +250,7 @@ def setup(rebalancer, providerA, providerB, gov, user, strategist):
     providerB.setRebalancer(rebalancer, {'from': gov})
 
     # 0.3%
-    rebalancer.setSwapFee(0.003 * 1e18, {'from': strategist})
+    rebalancer.setSwapFee(0.003 * 1e18, {'from': gov})
 
 
 @pytest.fixture
@@ -256,7 +258,7 @@ def setupTestOracle(rebalancerTestOracle, providerATestOracle, providerBTestOrac
     providerATestOracle.setRebalancer(rebalancerTestOracle, {'from': gov})
     providerBTestOracle.setRebalancer(rebalancerTestOracle, {'from': gov})
 
-    rebalancerTestOracle.setSwapFee(0.003 * 1e18, {'from': strategist})
+    rebalancerTestOracle.setSwapFee(0.003 * 1e18, {'from': gov})
 
 
 @pytest.fixture

--- a/tests/test_airdrops.py
+++ b/tests/test_airdrops.py
@@ -5,8 +5,8 @@ import util
 
 
 def test_airdrops(providerA, providerB, tokenA, tokenB, amountA, amountB, vaultA, vaultB, rebalancer,
-                         user,  gov, setup, rando, transferToRando, chain, testSetup, reward, reward_whale,
-                         whaleA, whaleB):
+                  user, gov, setup, rando, transferToRando, chain, testSetup, reward, reward_whale,
+                  whaleA, whaleB):
     beforeHarvestA = rebalancer.currentWeightA()
     beforeHarvestB = rebalancer.currentWeightB()
 
@@ -21,7 +21,7 @@ def test_airdrops(providerA, providerB, tokenA, tokenB, amountA, amountB, vaultA
     util.simulate_bal_reward(rebalancer, reward, reward_whale)
 
     ppsBeforeA = vaultA.pricePerShare()
-    ppsBeforeB = vaultA.pricePerShare()
+    ppsBeforeB = vaultB.pricePerShare()
 
     providerA.harvest({"from": gov})
     providerB.harvest({"from": gov})
@@ -44,8 +44,12 @@ def test_airdrops(providerA, providerB, tokenA, tokenB, amountA, amountB, vaultA
     util.stateOfStrat("after airdrop", rebalancer, providerA, providerB)
 
     ppsBeforeA = vaultA.pricePerShare()
-    ppsBeforeB = vaultA.pricePerShare()
+    ppsBeforeB = vaultB.pricePerShare()
 
+    # puts the airdrops into the lp
+    providerA.tend({"from": gov})
+
+    # harvest the gains from airdrop
     providerA.harvest({"from": gov})
     providerB.harvest({"from": gov})
 
@@ -56,4 +60,3 @@ def test_airdrops(providerA, providerB, tokenA, tokenB, amountA, amountB, vaultA
 
     assert vaultA.pricePerShare() > ppsBeforeA
     assert vaultB.pricePerShare() > ppsBeforeB
-

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -32,3 +32,23 @@ def test_triggers(providerATestOracle, providerBTestOracle, tokenA, tokenB, amou
 
     assert providerATestOracle.tendTrigger(0) == False
     assert providerBTestOracle.tendTrigger(0) == False
+
+    # price drops to something that will cause weights to hit the boundary. Test that public swap disables.
+    testOracleB.setPrice(oracleB.latestAnswer() * 0.001, {'from': rando})
+    assert providerBTestOracle.tendTrigger(0) == True
+
+    util.stateOfStrat("skewed", rebalancerTestOracle, providerATestOracle, providerBTestOracle)
+
+    providerBTestOracle.tend({'from': gov})
+
+    assert rebalancerTestOracle.getPublicSwap() == False
+    assert providerATestOracle.tendTrigger(0) == False
+    assert providerBTestOracle.tendTrigger(0) == False
+
+    # when vault managers do some debt adjustment or when price goes back up to a healthy weight balance,
+    # the next tend will enable swap again. In this case we simulate price going back up.
+    testOracleB.setPrice(oracleB.latestAnswer(), {'from': rando})
+    assert providerBTestOracle.tendTrigger(0) == True
+    providerBTestOracle.tend({'from': gov})
+
+    util.stateOfStrat("normal", rebalancerTestOracle, providerATestOracle, providerBTestOracle)


### PR DESCRIPTION
> <img src="https://user-images.githubusercontent.com/87678219/135965255-023e0104-c667-4a08-a731-645cd3d20bef.png" height="150"/>
Rebalancing will be powered by yearn's keeper jobs which will be monitoring `tendTrigger/shouldTend` by the minute and call `tend` as necessary. No micromanaging is needed.

> <img src="https://user-images.githubusercontent.com/87678219/135969498-b6efb2a8-cbbf-4abd-a4ea-b1f88c16c18a.png" height="150"/>
Similar to the above point. IL won't be realized if tended properly. The cost of tending will be justified once it reaches economies of scale (i.e. high TVL). Could try to mitigate cost of tending early on by raising the swap fee so a larger price fluctuation is needed to trigger tend.

> <img src="https://user-images.githubusercontent.com/87678219/135965605-dc193756-3b5a-4bed-a57c-9a15b5e590b7.png" height="150"/>
Although this is safer, it's not really necessary as it really bloats up the contract bytecode size. Vault accesses are all the same from what I know.


> <img src="https://user-images.githubusercontent.com/87678219/135966478-5cc6a3cc-9e42-4f54-8d84-45411bccd64e.png"/>
`exitPool` is used in 4 different occasions throughout the contract so it benefits from the use of a single internal function while `joinPool` is only used once so would not be necessary.  

> <img src="https://user-images.githubusercontent.com/87678219/135967585-21c76755-5495-49cf-9fa6-1f15be9f160c.png"/>
If enough isn't liquidated, the `Vault`'s `pricePerShare` will decrease proportional to how much was short vs. TVL. `AmountNeededMore` is used because there could be loose funds sitting in `JointProvider` already that hasn't been transferred to `Rebalancer` to LP yet which could be used. 


> <img src="https://user-images.githubusercontent.com/87678219/135966893-b376ce2b-6257-422d-aed9-f60d241f8f83.png"/>
The logic isn't really superfluous as each of `prepareReturn` and `liquidatePosition` could be called independently by the `Vault` at different stages of the `Vault` cycle, so they need to contain their own calculations of changes. Yes `liquidatePosition` is reused inside `prepareReturn` which'll save a lot of duplicated logic.

> <img src="https://user-images.githubusercontent.com/87678219/135968339-a50cc84e-a16b-45e8-ac05-de491dd6a9ee.png" height="150"/>
Having sole ownership of the private balancer pool + using private tx pools when exiting should be able to mitigate this

> <img src="https://user-images.githubusercontent.com/87678219/135968777-b0738098-fdd5-4e85-9dd8-3f554e2f53aa.png" height="100"/>
In BalancerV2, `Rebalancer` can't be migrated anymore as the pool owner can't be changed. The only way to migrate is to exit all funds out and deposit into a new pool/rebalancer contract.
There are 2 schools of thoughts for `ProtectedToken` amongst the strategists. I lean towards the side of leaving this blank so that in emergency cases, yearn `governance` can always sweep and rescue the tokens/funds/positions (and payback users manually or send to a fixed contract) so they never get bricked inside a faulty strategy. 

> <img src="https://user-images.githubusercontent.com/87678219/135970990-8b23dc98-93bf-4f6b-8f7f-6ab2a3325d68.png"/> 
This provides another emergency exit avenue to the yearn multisigs if the providers aren't functioning correctly. Similar to sweep by less extreme